### PR TITLE
we should use "Operation hooks"

### DIFF
--- a/lib/domain/item-schema.js
+++ b/lib/domain/item-schema.js
@@ -247,12 +247,12 @@ ItemSchema.afterInitialize = function() {
     this.links = this.allLinks();
 };
 
-ItemSchema.beforeSave = function(next, data) {
-    this.update$schema();
-    this.links = this.customLinks();
-    modelPropertiesConverter.convert(data);
+ItemSchema.observe('before save', function beforeSave(ctx, next) {
+    ctx.instance.update$schema();
+    ctx.instance.links = ctx.instance.customLinks();
+    modelPropertiesConverter.convert(ctx);
     next();
-};
+});
 
 ItemSchema.observe('after save', function afterSave(ctx, next) {
     var schema = ctx.instance;


### PR DESCRIPTION
because of the loopback deprecated warning - 
see https://github.com/backstage/loopback-jsonschema/issues/17