### PR TITLE
Fix dotted index issue

### DIFF
--- a/lib/domain/model-properties-converter.js
+++ b/lib/domain/model-properties-converter.js
@@ -1,11 +1,12 @@
 var modelPropertiesConverter = {
     convert: function(data) {
         if (data.indexes) {
-            findIndexes(data.indexes, function(indexObject, index){
-                if (index.indexOf('.') >= 0){
-                    data.indexes[indexObject][index.replace('.', '%2E')] =
-                    data.indexes[indexObject][index];
-                    delete data.indexes[indexObject][index];
+            findKeys(data.indexes, function(keys){
+                for (keyIndex in keys) {
+                    if (keyIndex.indexOf('.') >= 0) {
+                        keys[keyIndex.replace('.', '%2E')] = keys[keyIndex];
+                        delete keys[keyIndex];
+                    }
                 }
             });
         }
@@ -19,11 +20,13 @@ var modelPropertiesConverter = {
 
     restore: function(model) {
         if (model.indexes) {
-            findIndexes(model.indexes, function(indexObject, index){
-                if (index.indexOf('%2E') >= 0){
-                    model.indexes[indexObject][index.replace('%2E', '.')] =
-                    model.indexes[indexObject][index];
-                    delete model.indexes[indexObject][index];
+            findKeys(model.indexes, function(keys){
+                for (keyIndex in keys) {
+                    var key = keys[keyIndex];
+                    if (keyIndex.indexOf('%2E') >= 0){
+                        keys[keyIndex.replace('%2E', '.')] = keys[keyIndex];
+                        delete keys[keyIndex];
+                    }
                 }
             });
         }
@@ -36,16 +39,18 @@ var modelPropertiesConverter = {
     }
 };
 
+function getIndexKeys(index) {
+    return index.keys? index.keys: index;
+}
+
 function sanitizeSchema(data, value) {
     data['%24schema'] = value;
     delete data.$schema;
 }
 
-function findIndexes(indexes, operation){
+function findKeys(indexes, operation){
     for (var indexObject in indexes) {
-        for (var index in indexes[indexObject]) {
-            operation(indexObject, index);
-        }
+        operation(getIndexKeys(indexes[indexObject]));
     }
 }
 

--- a/lib/domain/model-properties-converter.js
+++ b/lib/domain/model-properties-converter.js
@@ -20,7 +20,7 @@ var modelPropertiesConverter = {
 
     restore: function(model) {
         if (model.indexes) {
-            findKeys(model.indexes, function(keys){
+            findKeys(model.indexes, function(keys) {
                 for (keyIndex in keys) {
                     var key = keys[keyIndex];
                     if (keyIndex.indexOf('%2E') >= 0){
@@ -48,7 +48,7 @@ function sanitizeSchema(data, value) {
     delete data.$schema;
 }
 
-function findKeys(indexes, operation){
+function findKeys(indexes, operation) {
     for (var indexObject in indexes) {
         operation(getIndexKeys(indexes[indexObject]));
     }

--- a/test/unit/domain/model-properties-converter.test.js
+++ b/test/unit/domain/model-properties-converter.test.js
@@ -16,6 +16,21 @@ describe('modelPropertiesConverter', function() {
                 }
             });
 
+            this.jsonSchemaWithKeys = new ItemSchema({
+                'collectionName': 'testKeys',
+                "indexes": {
+                    "file_width_index": {
+                        "keys": {
+                            "file.width": 1,
+                            "file.height": 1,
+                        },
+                        "options": {
+                            "unique": true
+                        }
+                    }
+                }
+            });
+
             this.jsonSchema.update$schema();
             this.jsonSchema.__data.$schema = this.jsonSchema.$schema; // __data.$schema will be defined when a post is received
         });
@@ -47,6 +62,36 @@ describe('modelPropertiesConverter', function() {
                     this.jsonSchema['indexes']['file_width_index']['file.width']).
                 to.not.exist;
             });
+
+            it('should convert indexes with dotted keys to %2E', function() {
+                modelPropertiesConverter.convert(this.jsonSchemaWithKeys);
+                expect(
+                    this.jsonSchemaWithKeys['indexes']['file_width_index']['keys']['file%2Ewidth']).
+                to.exist;
+                expect(
+                    this.jsonSchemaWithKeys['indexes']['file_width_index']['keys']['file.width']).
+                to.not.exist;
+            });
+
+            it('should convert indexes with dotted keys to %2E', function() {
+                modelPropertiesConverter.convert(this.jsonSchemaWithKeys);
+                expect(
+                    this.jsonSchemaWithKeys['indexes']['file_width_index']['keys']['file%2Ewidth']).
+                to.exist;
+                expect(
+                    this.jsonSchemaWithKeys['indexes']['file_width_index']['keys']['file.width']).
+                to.not.exist;
+            });
+
+            it('should not change options in the indexes definitions while converting dotted keys to %2E', function() {
+                expect(
+                    this.jsonSchemaWithKeys['indexes']['file_width_index']['options']['unique']).
+                to.be.true;
+                modelPropertiesConverter.convert(this.jsonSchemaWithKeys);
+                expect(
+                    this.jsonSchemaWithKeys['indexes']['file_width_index']['options']['unique']).
+                to.be.true;
+            });
         });
 
         describe('.restore', function() {
@@ -63,6 +108,25 @@ describe('modelPropertiesConverter', function() {
             });
 
             it('should restore indexes with %2E to dot', function() {
+                expect(
+                    this.jsonSchema['indexes']['file_width_index']['file%2Ewidth']).
+                to.not.exist;
+                expect(
+                    this.jsonSchema['indexes']['file_width_index']['file.width']).
+                to.exist;
+            });
+
+            it('should restore indexes with %2E to dot', function() {
+                expect(
+                    this.jsonSchema['indexes']['file_width_index']['file%2Ewidth']).
+                to.not.exist;
+                expect(
+                    this.jsonSchema['indexes']['file_width_index']['file.width']).
+                to.exist;
+            });
+
+            it('should restore indexes with %2E\'d keys  to dot', function() {
+
                 expect(
                     this.jsonSchema['indexes']['file_width_index']['file%2Ewidth']).
                 to.not.exist;


### PR DESCRIPTION
I was trying to create an index as bellow:
```
...
    "indexes": {
        "index1": {
            "keys": {"field": 1, "field.subfield": 1},
            "options": {"unique": true}
        }
    }
...
```
And was having a problem with loopback-jsonschema not correctly converting/restoring the index keys to feed mongodb. 

Upon investigation I found that the problem was that the code would only work for indexes defined as:
```
    "indexes": {
        "index1": {
            "field.subfield": 1
         }
    }
```

This patch fixes this. Please, let me know of any improvements this needs.