### PR TITLE
fix: provide a consistent way to preserve index key order

### DIFF
--- a/lib/domain/model-properties-converter.js
+++ b/lib/domain/model-properties-converter.js
@@ -1,6 +1,7 @@
 var modelPropertiesConverter = {
     convert: function(data) {
         if (data.indexes) {
+            normalizeKeys(data.indexes);
             sanitizeIndexes(data.indexes, '.', '%2E');
         }
 
@@ -49,6 +50,29 @@ var modelPropertiesConverter = {
         }
     }
 };
+
+function normalizeKeys(indexes) {
+    for(var k in indexes) {
+        var idx = indexes[k];
+        if('orderedKeys' in idx) {
+            idx.keys = arrayToOrderedObject(idx.orderedKeys) || idx.keys;
+            delete idx['orderedKeys'];
+        }
+    }
+}
+
+function arrayToOrderedObject(orderedKeys) {
+    if(!orderedKeys || !Array.isArray(orderedKeys)) {
+        return null;
+    }
+
+    var ordered = {};
+    for(var k = 0; k < orderedKeys.length; k++) {
+        ordered = Object.assign(ordered, orderedKeys[k]);
+    }
+
+    return ordered;
+}
 
 function getIndexKeys(index) {
     return index.keys? index.keys: index;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@globocom/loopback-jsonschema",
-  "version": "5.0.14",
+  "version": "5.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@globocom/loopback-jsonschema",
-  "version": "5.0.14",
+  "version": "5.0.15",
   "description": "JSON Schema support for Loopback",
   "main": "index.js",
   "scripts": {

--- a/test/unit/domain/extended-validation.test.js
+++ b/test/unit/domain/extended-validation.test.js
@@ -84,7 +84,7 @@ describe('ItemSchema extended validation', function() {
             done();
         });
 
-        it('should be detected', function() {
+        it('should not be detected', function() {
             errors = extendedValidation(itemSchema);
 
             expect(errors.length).to.eql(0);

--- a/test/unit/domain/item-schema.test.js
+++ b/test/unit/domain/item-schema.test.js
@@ -704,6 +704,54 @@ describe('ItemSchema', function() {
                 expect(order).to.eql(expectedOrder)
             });
         });
+
+        describe('when sanitizing keys in ordered list', function() {
+            beforeEach(function() {
+                schema['$schema'] = 'http://json-schema.org/draft-03/hyper-schema#';
+                schema.indexes = {
+                    "file_width_index": {
+                        "orderedKeys": [
+                            {"file.width": 1},
+                            {"file.height": 1},
+                            {"placeholder": 1},
+                            {"placeholder.onelevel": 1},
+                            {"placeholder.onelevel.onemorelevel": 1},
+                            {"somethingelse": -1}
+                        ],
+                        "options": {
+                            "unique": true
+                        }
+                    }
+                };
+                itemSchema = ItemSchema(schema);
+                itemSchema.sanitizeForDatabase();
+            });
+
+            it('should convert indexes', function() {
+                expect(itemSchema.indexes.file_width_index.keys).to.eql({
+                    'file%2Ewidth': 1,
+                    'file%2Eheight': 1,
+                    'placeholder': 1, 
+                    'placeholder%2Eonelevel': 1,
+                    'placeholder%2Eonelevel%2Eonemorelevel': 1,
+                    'somethingelse': -1
+                });
+            });
+
+            it('should preserve keys order', function() {
+                var expectedOrder = [
+                    'file%2Ewidth',
+                    'file%2Eheight',
+                    'placeholder',
+                    'placeholder%2Eonelevel',
+                    'placeholder%2Eonelevel%2Eonemorelevel',
+                    'somethingelse'
+                ];
+                var order = Object.keys(itemSchema.indexes.file_width_index.keys)
+                expect(order).to.eql(expectedOrder)
+            });
+
+        });
     });
 
     describe('.validate(\'relations\')', function(){


### PR DESCRIPTION
dictionaries/hashes/maps are not the way to do that.